### PR TITLE
nvidia driver version 410

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ installpackages=""
 # Thermal management stuff and packages
 installpackages+="thermald tlp tlp-rdw powertop "
 # Nvidia
-installpackages+="nvidia-driver-396 nvidia-prime bbswitch-dkms pciutils "
+installpackages+="nvidia-driver-410 nvidia-prime bbswitch-dkms pciutils "
 # Streaming and codecs for correct video encoding/play
 installpackages+="va-driver-all vainfo libva2 gstreamer1.0-libav gstreamer1.0-vaapi "
 # Others

--- a/xps-tweaks.sh
+++ b/xps-tweaks.sh
@@ -29,7 +29,7 @@ systemctl restart tlp
 # Install the latest nVidia driver and codecs
 add-apt-repository -y ppa:graphics-drivers/ppa
 apt -y update
-apt -y install nvidia-driver-396 nvidia-prime bbswitch-dkms pciutils
+apt -y install nvidia-driver-410 nvidia-prime bbswitch-dkms pciutils
 
 # Install codecs
 apt -y install ubuntu-restricted-extras va-driver-all vainfo libva2 gstreamer1.0-libav gstreamer1.0-vaapi


### PR DESCRIPTION
## What this PR does
Changes script to use the newer Nvidia driver version.

## Why
The 396 version is a short lived branch of the driver (ie its a beta version). Version 410 is on a long lived branch.

## How to test
Just run the script. I haven't actually done benchmarking to test the actual benefits from upgrading driver versions but you can check the official changelog [on nvidia's website](https://www.geforce.com/drivers/results/138959)