### PR TITLE
32bit OpenGL libraries

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ installpackages=""
 # Thermal management stuff and packages
 installpackages+="thermald tlp tlp-rdw powertop "
 # Nvidia
-installpackages+="nvidia-driver-410 nvidia-prime bbswitch-dkms pciutils "
+installpackages+="nvidia-driver-410 libnvidia-gl-396:i386 nvidia-prime bbswitch-dkms pciutils "
 # Streaming and codecs for correct video encoding/play
 installpackages+="va-driver-all vainfo libva2 gstreamer1.0-libav gstreamer1.0-vaapi "
 # Others

--- a/xps-tweaks.sh
+++ b/xps-tweaks.sh
@@ -29,7 +29,7 @@ systemctl restart tlp
 # Install the latest nVidia driver and codecs
 add-apt-repository -y ppa:graphics-drivers/ppa
 apt -y update
-apt -y install nvidia-driver-410 nvidia-prime bbswitch-dkms pciutils
+apt -y install nvidia-driver-410 libnvidia-gl-396:i386 nvidia-prime bbswitch-dkms pciutils
 
 # Install codecs
 apt -y install ubuntu-restricted-extras va-driver-all vainfo libva2 gstreamer1.0-libav gstreamer1.0-vaapi


### PR DESCRIPTION
## What this PR does
Adds support for 32bit OpenGL libraries. I stumbled upon this issue when trying to run Steam and got the error `glXChooseVisual failed`. It's an easy fix although I'm not sure if something like this should be made optional to the user.