### PR TITLE
Fixed nvidia version typo

### DIFF
--- a/xps-tweaks.sh
+++ b/xps-tweaks.sh
@@ -29,7 +29,7 @@ systemctl restart tlp
 # Install the latest nVidia driver and codecs
 add-apt-repository -y ppa:graphics-drivers/ppa
 apt -y update
-apt -y install nvidia-driver-410 libnvidia-gl-396:i386 nvidia-prime bbswitch-dkms pciutils
+apt -y install nvidia-driver-410 libnvidia-gl-410 nvidia-prime bbswitch-dkms pciutils
 
 # Install codecs
 apt -y install ubuntu-restricted-extras va-driver-all vainfo libva2 gstreamer1.0-libav gstreamer1.0-vaapi


### PR DESCRIPTION
I noticed that the version for libnvidia-gl was still 396 and using 32-bit libraries, which were refusing to install on my machine. I corrected it to 410 and it worked fine.