### PR TITLE
Fixes post install exiting if no codecs need to be installed

### DIFF
--- a/xps-tweaks.sh
+++ b/xps-tweaks.sh
@@ -36,7 +36,7 @@ echo "Do you wish to install video codecs for encoding and playing videos?"
 select yn in "Yes" "No"; do
     case $yn in
         Yes ) apt -y install ubuntu-restricted-extras va-driver-all vainfo libva2 gstreamer1.0-libav gstreamer1.0-vaapi; break;;
-        No ) exit;;
+        No ) break;;
     esac
 done
 


### PR DESCRIPTION
Hi,
I was using your post-install script and noticed that if the answer to the installation of additional codecs was no, the script would just exit without proceeding with the additional steps. My guess is that it shouldn't be the desired behaviour. Correct me if I'm wrong.