### PR TITLE
Disable Intel Sound HDA to eliminate occasional sound cracking

### DIFF
--- a/wrapper-audio.sh
+++ b/wrapper-audio.sh
@@ -91,6 +91,17 @@ default-fragment-size-msec = 125
 deferred-volume-safety-margin-usec = 1
 ; deferred-volume-extra-delay-usec = 0" > /etc/pulse/daemon.conf
 
+
+echo "#disable suspend on idle
+.include /etc/pulse/default.pa
+unload-module module-suspend-on-idle
+
+#fix audio stuttering with wifi stream
+load-module module-null-sink sink_name=rtp
+load-module module-rtp-send source=rtp.monitor
+set-default-sink rtp
+load-module module-rtp-recv" > ~/.config/pulse/default.pa
+
 # Enable LDAC, APTX, APTX-HD, AAC support in PulseAudio Bluetooth module
 add-apt-repository ppa:eh5/pulseaudio-a2dp
 apt-get update

--- a/wrapper-audio.sh
+++ b/wrapper-audio.sh
@@ -91,13 +91,6 @@ default-fragment-size-msec = 125
 deferred-volume-safety-margin-usec = 1
 ; deferred-volume-extra-delay-usec = 0" > /etc/pulse/daemon.conf
 
-# Disable Intel Sound HDA power saving to eliminate sound cracking
-# Temporary fix
-echo 0 > /sys/module/snd_hda_intel/parameters/power_save
-# Permament fix (will continue working after reboot)
-touch /etc/modprobe.d/audio_powersave.conf
-echo options snd_hda_intel power_save=0 > /etc/modprobe.d/audio_powersave.conf
-
 # Enable LDAC, APTX, APTX-HD, AAC support in PulseAudio Bluetooth module
 add-apt-repository ppa:eh5/pulseaudio-a2dp
 apt-get update

--- a/wrapper-audio.sh
+++ b/wrapper-audio.sh
@@ -91,6 +91,13 @@ default-fragment-size-msec = 125
 deferred-volume-safety-margin-usec = 1
 ; deferred-volume-extra-delay-usec = 0" > /etc/pulse/daemon.conf
 
+# Disable Intel Sound HDA power saving to eliminate sound cracking
+# Temporary fix
+echo 0 > /sys/module/snd_hda_intel/parameters/power_save
+# Permament fix (will continue working after reboot)
+touch /etc/modprobe.d/audio_powersave.conf
+echo options snd_hda_intel power_save=0 > /etc/modprobe.d/audio_powersave.conf
+
 # Enable LDAC, APTX, APTX-HD, AAC support in PulseAudio Bluetooth module
 add-apt-repository ppa:eh5/pulseaudio-a2dp
 apt-get update

--- a/xps-tweaks.sh
+++ b/xps-tweaks.sh
@@ -137,6 +137,16 @@ deferred-volume-safety-margin-usec = 1
     esac
 done
 
+echo "#disable suspend on idle
+.include /etc/pulse/default.pa
+unload-module module-suspend-on-idle
+
+#fix audio stuttering with wifi stream
+load-module module-null-sink sink_name=rtp
+load-module module-rtp-send source=rtp.monitor
+set-default-sink rtp
+load-module module-rtp-recv" > ~/.config/pulse/default.pa
+
 # Enable LDAC, APTX, APTX-HD, AAC support in PulseAudio Bluetooth
 add-apt-repository ppa:eh5/pulseaudio-a2dp
 apt-get update

--- a/xps-tweaks.sh
+++ b/xps-tweaks.sh
@@ -137,13 +137,6 @@ deferred-volume-safety-margin-usec = 1
     esac
 done
 
-# Disable Intel Sound HDA power saving to eliminate sound cracking
-# Temporary fix
-echo 0 > /sys/module/snd_hda_intel/parameters/power_save
-# Permament fix (will continue working after reboot)
-touch /etc/modprobe.d/audio_powersave.conf
-echo options snd_hda_intel power_save=0 > /etc/modprobe.d/audio_powersave.conf
-
 # Enable LDAC, APTX, APTX-HD, AAC support in PulseAudio Bluetooth
 add-apt-repository ppa:eh5/pulseaudio-a2dp
 apt-get update

--- a/xps-tweaks.sh
+++ b/xps-tweaks.sh
@@ -137,6 +137,13 @@ deferred-volume-safety-margin-usec = 1
     esac
 done
 
+# Disable Intel Sound HDA power saving to eliminate sound cracking
+# Temporary fix
+echo 0 > /sys/module/snd_hda_intel/parameters/power_save
+# Permament fix (will continue working after reboot)
+touch /etc/modprobe.d/audio_powersave.conf
+echo options snd_hda_intel power_save=0 > /etc/modprobe.d/audio_powersave.conf
+
 # Enable LDAC, APTX, APTX-HD, AAC support in PulseAudio Bluetooth
 add-apt-repository ppa:eh5/pulseaudio-a2dp
 apt-get update


### PR DESCRIPTION
I had issues with youtube videos, where every now and then sound was slightly popping/cracking. This patch is reported by multiple sources to fix these issues and not cause major power draw. It works for me and sound cracking has been eliminated from my 9570.