### PR TITLE
Optionally fix headphone feedback on battery and disable fingerprint reader

### DIFF
--- a/xps-tweaks.sh
+++ b/xps-tweaks.sh
@@ -215,4 +215,14 @@ select yn in "Yes" "No"; do
     esac
 done
 
+# Ask for disabling fingerprint reader
+echo "Do you wish to disable the fingerprint reader to save power (no linux driver is available for this device)?"
+select yn in "Yes" "No"; do
+    case $yn in
+        Yes ) echo "# Disable fingerprint reader
+SUBSYSTEM==\"usb\", ATTRS{idVendor}==\"27c6\", ATTRS{idProduct}==\"5395\", ATTR{authorized}=\"0\"" > /etc/udev/rules.d/fingerprint.rules; break;;
+        No ) break;;
+    esac
+done
+
 echo "FINISHED! Please reboot the machine!"

--- a/xps-tweaks.sh
+++ b/xps-tweaks.sh
@@ -33,6 +33,15 @@ add-apt-repository -y ppa:graphics-drivers/ppa
 apt -y update
 ubuntu-drivers autoinstall
 
+# Fix Audio Feedback/White Noise from Headphones on Battery Bug
+echo "Do you wish to fix the headphone white noise on battery bug? (if you do not have this issue, there is no need to enable it) (may impact battery life)"
+select yn in "Yes" "No"; do
+    case $yn in
+        Yes ) sed -i '/SOUND_POWER_SAVE_ON_BAT/s/=.*/=0/' /etc/default/tlp; systemctl restart tlp; break;;
+        No ) break;;
+    esac
+done
+
 # Install codecs
 echo "Do you wish to install video codecs for encoding and playing videos?"
 select yn in "Yes" "No"; do
@@ -43,7 +52,7 @@ select yn in "Yes" "No"; do
 done
 
 # Enable high quality audio
-echo "Do you wish to enable high quality audio? (may impact on battery life)"
+echo "Do you wish to enable high quality audio? (may impact battery life)"
 select yn in "Yes" "No"; do
     case $yn in
         Yes ) echo "# This file is part of PulseAudio.


### PR DESCRIPTION
I had an issue with white noise when I plugged my headphones in while on battery, a very annoying bug. I researched the issue and found out it was due to the tlp "SOUND_POWER_SAVE_ON_BAT=1" default value, this pull request allows the user to optionally enable the fix if they have similar issues.

I also added an option to disable the fingerprint reader entirely to save battery as there is no linux driver for the device. Here is my /var/log/kern.log showing that this fix actually disables it:

kernel: [ 9676.658319] xhci_hcd 0000:3a:00.0: USB bus 3 deregistered